### PR TITLE
Fix typo in readme.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ This script will simply add some generic CORS configuration to your CouchDB. You
 ```bash
 HOST=http://adminname:password@localhost:5984 # or whatever you got
 
-curl -X POST $HOST/_config/httpd/enable_cors -d '"true"'
+curl -X PUT $HOST/_config/httpd/enable_cors -d '"true"'
 curl -X PUT $HOST/_config/cors/origins -d '"*"'
 curl -X PUT $HOST/_config/cors/credentials -d '"true"'
 curl -X PUT $HOST/_config/cors/methods -d '"GET, PUT, POST, HEAD, DELETE"'


### PR DESCRIPTION
The first command in the readme doesn't work because it says to use
POST, but only GET, PUT and DELETE are supported for config. This makes
the readme example match the script's behaviour.