### PR TITLE
fix(nodes): fix urls to access to cluster nodes configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function doCouch2(baseUrl, auth, membershipResp) {
   return membershipResp.json().then(function (members) {
     return Promise.all(members.cluster_nodes.map(function (node) {
       return Promise.all(requests.map(function (req) {
-        var path = '/_node/' + node + '/' + req.path;
+        var path = '/_node/' + node + req.path;
         var urlString = formatUrl(baseUrl, auth, path);
         return updateConfig(urlString, req.value);
       }));


### PR DESCRIPTION
This makes add-cors-to-couchdb fail on pouchdb-server:
```
> node_modules/.bin/add-cors-to-couchdb
[info] GET /_membership 200 - 127.0.0.1
[info] PUT /_node/node1@127.0.0.1//_config/httpd/enable_cors 404 - 127.0.0.1
[info] PUT /_node/node1@127.0.0.1//_config/cors/origins 404 - 127.0.0.1
[info] PUT /_node/node1@127.0.0.1//_config/cors/credentials 404 - 127.0.0.1
[info] PUT /_node/node1@127.0.0.1//_config/cors/methods 404 - 127.0.0.1
[info] PUT /_node/node1@127.0.0.1//_config/cors/headers 404 - 127.0.0.1
```